### PR TITLE
Adjust the way readlink is called for Microtest to work on macOS

### DIFF
--- a/src/microtest/backtrace_printer.cr
+++ b/src/microtest/backtrace_printer.cr
@@ -1,6 +1,11 @@
 module Microtest
-  CRYSTAL_EXECUTABLE = {{system("readlink -f `which crystal`").stringify}}
-  CRYSTAL_DIR        = CRYSTAL_EXECUTABLE.strip.sub("/embedded/bin/crystal", "")
+  {% if flag?(:darwin) %}
+    CRYSTAL_EXECUTABLE = {{system("readlink `which crystal`").stringify}}
+  {% else %}
+    CRYSTAL_EXECUTABLE = {{system("readlink -f `which crystal`").stringify}}
+  {% end %}
+
+  CRYSTAL_DIR = CRYSTAL_EXECUTABLE.strip.sub("/embedded/bin/crystal", "")
 
   STRACKTRACE_LINE_REGEX = /\A(.+):(\d+):(\d+) in \'(\S+)\'\z/
 


### PR DESCRIPTION
`readlink` that comes with macOS doesn't have an `-f` argument, so it crashes, causing the tests to crash. I've conditionally removed this argument in the event that someone is using Microtest on macOS.