### PR TITLE
Fix miscellaneous spec failures for Crystal 1.18

### DIFF
--- a/spec/power_assert_spec.cr
+++ b/spec/power_assert_spec.cr
@@ -49,7 +49,7 @@ describe Microtest::PowerAssert do
 
     assert reflect(yielding(1) { |x| x }) == CallNode.new(
       %[yielding],
-      %[yielding(1) do |x|\n  x\nend],
+      %[yielding(1) do |x| x end],
       2001,
       EmptyNode.new,
       [TerminalNode.new("1", 1)] of Node,

--- a/spec/termart_spec.cr
+++ b/spec/termart_spec.cr
@@ -25,14 +25,14 @@ describe Microtest::Termart do
   test "grouped_lines with color" do
     res = grouped_lines(["A: aaa"], RED, colorize: true)
 
-    assert res == %{\e[38;2;220;0;0m◆\e[0m A: aaa\n}
+    assert res == %{\e[38;2;220;0;0m◆\e[39m A: aaa\n}
 
     res = grouped_lines(["A: aaa", "B: bbb", "C: ccc"], RED, colorize: true)
 
     assert res == <<-STR
-    \e[38;2;220;0;0m┏\e[0m A: aaa
-    \e[38;2;220;0;0m┃\e[0m B: bbb
-    \e[38;2;220;0;0m┗\e[0m C: ccc\n
+    \e[38;2;220;0;0m┏\e[39m A: aaa
+    \e[38;2;220;0;0m┃\e[39m B: bbb
+    \e[38;2;220;0;0m┗\e[39m C: ccc\n
     STR
   end
 end

--- a/src/microtest/termart.cr
+++ b/src/microtest/termart.cr
@@ -36,7 +36,7 @@ module Microtest
 
     private def colorized_io(fg : RGB? = nil, bg : RGB? = nil, m : Colorize::Mode? = nil, &)
       if colorize?
-        c = Colorize.with
+        c = Colorize.with.toggle(true)
         c = c.fore(fg) if fg
         c = c.mode(m) if m
         c = c.back(bg) if bg


### PR DESCRIPTION
- Makes the specs expect the correct closing ANSI escape sequences, rather than `\e[0m` all the time (crystal-lang/crystal#16052).
- Always enables colorization, since child processes now respect `Colorize.on_tty_only!` by default (crystal-lang/crystal#15881).
- Makes a spec expect a single-line block to be printed on a single line as well (crystal-lang/crystal#15568).

(I didn't edit the minimum Crystal version in `shard.yml`)