### PR TITLE
Support Windows MSVC / MinGW-w64

### DIFF
--- a/spec/backtrace_printer_spec.cr
+++ b/spec/backtrace_printer_spec.cr
@@ -40,6 +40,11 @@ describe Microtest::BacktracePrinter do
     ???
     BACKTRACE
 
+    # backtraces on MSVC do not have column numbers
+    {% if flag?(:msvc) %}
+      raw_trace.map! &.sub(/:\d+ in/, " in")
+    {% end %}
+
     printer = Microtest::BacktracePrinter.new
 
     pretty_trace = printer.call(raw_trace, colorize: false)

--- a/spec/backtrace_printer_spec.cr
+++ b/spec/backtrace_printer_spec.cr
@@ -49,25 +49,27 @@ describe Microtest::BacktracePrinter do
 
     pretty_trace = printer.call(raw_trace, colorize: false)
 
+    s = Path::SEPARATORS[0]
+
     assert pretty_trace == <<-BACKTRACE
-    ┏ CRY: /crystal/main.cr:119 main
-    ┃ CRY: /crystal/main.cr:96 main
-    ┃ CRY: /crystal/main.cr:110 main_user_code
-    ┃ SPEC: spec/spec_helper.cr:64 __crystal_main
-    ┃ APP: src/microtest.cr:67 run!
-    ┃ APP: src/microtest.cr:71 run!
-    ┃ APP: src/microtest.cr:53 run
-    ┃ APP: src/microtest.cr:55 run
-    ┃ APP: src/microtest/runner.cr:25 call
-    ┃ APP: src/microtest/test.cr:36 run_tests
-    ┃ CRY: /primitives.cr:255 call
-    ┃ SPEC: spec/backtrace_printer_spec.cr:17 ->
-    ┃ APP: src/microtest/test.cr:52 run_test
-    ┃ CRY: /primitives.cr:255 around_hooks
-    ┃ CRY: /primitives.cr:255 ->
-    ┃ SPEC: spec/backtrace_printer_spec.cr:17 ->
-    ┃ SPEC: spec/backtrace_printer_spec.cr:19 test__prettify_path
-    ┗ SPEC: spec/backtrace_printer_spec.cr:5 generate_exception\n
+    ┏ CRY: #{s}crystal#{s}main.cr:119 main
+    ┃ CRY: #{s}crystal#{s}main.cr:96 main
+    ┃ CRY: #{s}crystal#{s}main.cr:110 main_user_code
+    ┃ SPEC: spec#{s}spec_helper.cr:64 __crystal_main
+    ┃ APP: src#{s}microtest.cr:67 run!
+    ┃ APP: src#{s}microtest.cr:71 run!
+    ┃ APP: src#{s}microtest.cr:53 run
+    ┃ APP: src#{s}microtest.cr:55 run
+    ┃ APP: src#{s}microtest#{s}runner.cr:25 call
+    ┃ APP: src#{s}microtest#{s}test.cr:36 run_tests
+    ┃ CRY: #{s}primitives.cr:255 call
+    ┃ SPEC: spec#{s}backtrace_printer_spec.cr:17 ->
+    ┃ APP: src#{s}microtest#{s}test.cr:52 run_test
+    ┃ CRY: #{s}primitives.cr:255 around_hooks
+    ┃ CRY: #{s}primitives.cr:255 ->
+    ┃ SPEC: spec#{s}backtrace_printer_spec.cr:17 ->
+    ┃ SPEC: spec#{s}backtrace_printer_spec.cr:19 test__prettify_path
+    ┗ SPEC: spec#{s}backtrace_printer_spec.cr:5 generate_exception\n
     BACKTRACE
   end
 

--- a/spec/hooks_spec.cr
+++ b/spec/hooks_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe MicrotestHooks do
   test "before and after hook" do
     result = record_test_json do
-      {{`cat spec/hook_examples/before_and_after_hooks.cr`}}
+      {{ read_file("#{__DIR__}/hook_examples/before_and_after_hooks.cr").id }}
     end
 
     assert result.success?
@@ -78,7 +78,7 @@ describe MicrotestHooks do
 
   test "around hook" do
     result = record_test_json do
-      {{`cat spec/hook_examples/around_hook.cr`}}
+      {{ read_file("#{__DIR__}/hook_examples/around_hook.cr").id }}
     end
 
     assert result.json["results"]["AroundHookTest#first"]["type"] == "Microtest::TestSuccess"
@@ -90,7 +90,7 @@ describe MicrotestHooks do
     # and crystal would interpret the yield as belonging to the test method, which makes
     # it fail to compile because that parameter would be missing.
     result = record_test do
-      {{`cat spec/hook_examples/hook_order.cr`}}
+      {{ read_file("#{__DIR__}/hook_examples/hook_order.cr").id }}
     end
 
     assert result.success?

--- a/spec/readme_example_spec.cr
+++ b/spec/readme_example_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe WaterPumpExample do
   test "waterpump example" do
     res = record_test_json do
-      {{`cat spec/examples/waterpump.cr`}}
+      {{ read_file("#{__DIR__}/examples/waterpump.cr").id }}
     end
 
     assert res.json["results"].as_h.keys.sort! == [
@@ -23,7 +23,7 @@ end
 describe AssertionFailureExample do
   test "assertion failure example" do
     res = record_test([Microtest::ErrorListReporter.new]) do
-      {{`cat spec/examples/assertion_failure.cr`}}
+      {{ read_file("#{__DIR__}/examples/assertion_failure.cr").id }}
     end
 
     assert !res.success?
@@ -35,7 +35,7 @@ end
 describe SummaryAndProgressRepoterExample do
   test "image" do
     res = record_test([Microtest::ProgressReporter.new, Microtest::ErrorListReporter.new, Microtest::SummaryReporter.new]) do
-      {{`cat spec/examples/multiple_tests.cr`}}
+      {{ read_file("#{__DIR__}/examples/multiple_tests.cr").id }}
     end
 
     assert !res.success?
@@ -46,7 +46,7 @@ end
 describe SummaryAndDescriptionRepoterExample do
   test "image" do
     res = record_test([Microtest::DescriptionReporter.new, Microtest::ErrorListReporter.new, Microtest::SummaryReporter.new]) do
-      {{`cat spec/examples/multiple_tests.cr`}}
+      {{ read_file("#{__DIR__}/examples/multiple_tests.cr").id }}
     end
 
     assert !res.success?
@@ -57,7 +57,7 @@ end
 describe FocusExample do
   test "image" do
     res = record_test([Microtest::DescriptionReporter.new, Microtest::ErrorListReporter.new, Microtest::SummaryReporter.new]) do
-      {{`cat spec/examples/focus.cr`}}
+      {{ read_file("#{__DIR__}/examples/focus.cr").id }}
     end
 
     assert res.success?

--- a/spec/reporters/error_list_reporter_spec.cr
+++ b/spec/reporters/error_list_reporter_spec.cr
@@ -49,6 +49,6 @@ describe Microtest::ErrorListReporter do
     output = uncolor(result.stdout)
 
     assert output.matches?(/ABORTED/)
-    assert output.matches?(%r{┗ SPEC: spec/test.cr:\d+ before_hooks})
+    assert output.matches?(%r{┗ SPEC: spec[/\\]test.cr:\d+ before_hooks})
   end
 end

--- a/spec/reporters/summary_reporter_spec.cr
+++ b/spec/reporters/summary_reporter_spec.cr
@@ -21,7 +21,7 @@ describe Microtest::SummaryReporter do
     assert !result.success?
 
     output = uncolor(result.stdout)
-    assert output.matches?(%r{Executed 3/3 tests in \d+µs with seed 1})
+    assert output.matches?(%r{Executed 3/3 tests in \d+[µm]s with seed 1})
     assert output.includes?("Success: 1, Skips: 1, Failures: 1")
   end
 

--- a/src/microtest.cr
+++ b/src/microtest.cr
@@ -105,6 +105,6 @@ module Microtest
 
   def self.run!(*args)
     success = run(*args)
-    exit(success ? 0 : -1)
+    exit(success ? 0 : 1)
   end
 end

--- a/src/microtest/backtrace_printer.cr
+++ b/src/microtest/backtrace_printer.cr
@@ -3,9 +3,15 @@ module Microtest
     # find the backtrace entry for crystals main method
     first_entry = caller.reverse.find { |l| %r{in 'main'} === l } || Microtest.bug("Could not determine crystal path from caller backtrace")
 
-    raw_path = Path.new(first_entry.split(":").first)
+    # file:line:column in 'symbol'
+    # (backtraces on MSVC do not have column numbers)
+    raw_path, _, _ = first_entry.partition(" in '")
+    raw_path, _, _ = raw_path.rpartition(":")
+    {% unless flag?(:msvc) %}
+      raw_path, _, _ = raw_path.rpartition(":")
+    {% end %}
 
-    parts = raw_path.parts
+    parts = Path.new(raw_path).parts
 
     # Move up from /???/crystal-1.16.0-1/share/crystal/src/crystal/system/unix/main.cr
     while parts.last != "src"

--- a/src/microtest/runner.cr
+++ b/src/microtest/runner.cr
@@ -16,10 +16,10 @@ module Microtest
       ctx = ExecutionContext.new(reporters, suites, random_seed)
       ctx.started
 
-      Signal::INT.trap {
+      Process.on_terminate do |reason|
         ctx.manually_abort!
-        Signal::INT.reset
-      }
+        Process.restore_interrupts!
+      end
 
       suites.shuffle(ctx.random).each do |suite|
         break if ctx.halted?


### PR DESCRIPTION
- Backtraces do not have column numbers on MSVC.
- Backslashes may be used as a directory separator on Windows. (it's up to you to decide whether microtest itself should convert backslashes to forward slashes.)
- `Signal` is not supported on Windows, the more portable `Process.on_terminate` is used instead.
- The failure exit code is now 1 instead of -1.
- Specs that read the contents of other Crystal source files use the `read_file` macro method instead of the `cat` command, which doesn't exist on Windows.